### PR TITLE
Fix problems with IE when getting orignal constructor for injecting properties

### DIFF
--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -533,6 +533,8 @@ Scope.Singleton = new SingletonScope();
  * Utility class to handle injection behavior on class decorations.
  */
 class InjectorHanlder {
+    static constructorNameRegEx = /function (\w*)/;
+
     static decorateConstructor(target: Function) {
         let newConstructor: any;
         // tslint:disable-next-line:class-name
@@ -544,6 +546,21 @@ class InjectorHanlder {
         };
         newConstructor['__parent'] = target;
         return newConstructor;
+    }
+
+    static hasNamedConstructor(source: Function): boolean {
+        if (source['name']) {
+            return source['name'] !== 'ioc_wrapper';
+        } else {
+            try {
+                const constructorName = source.prototype.constructor.toString().match(this.constructorNameRegEx)[1];
+                return (constructorName && constructorName !== 'ioc_wrapper');
+            } catch {
+                // make linter happy
+            }
+
+            return false;
+        }
     }
 
     static getConstructorFromType(target: Function): FunctionConstructor {

--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -565,11 +565,11 @@ class InjectorHanlder {
 
     static getConstructorFromType(target: Function): FunctionConstructor {
         let typeConstructor: any = target;
-        if (typeConstructor['name'] && typeConstructor['name'] !== 'ioc_wrapper') {
+        if (this.hasNamedConstructor(typeConstructor)) {
             return <FunctionConstructor>typeConstructor;
         }
         while (typeConstructor = typeConstructor['__parent']) {
-            if (typeConstructor['name'] && typeConstructor['name'] !== 'ioc_wrapper') {
+            if (this.hasNamedConstructor(typeConstructor)) {
                 return <FunctionConstructor>typeConstructor;
             }
         }


### PR DESCRIPTION
Fixes issue #12.
However, there is problem with tests coverige, as long as these changes are done in non-exported class, so I'm not able to run separate tests outside of the module.