### PR TITLE
Added generic type to 'get' an object from the container

### DIFF
--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -243,7 +243,7 @@ export class Container {
      * @param source The dependency type to resolve
      * @return an object resolved for the given source type;
      */
-    static get(source: Function) {
+    static get<T extends Function>(source: T) : T[keyof T] {
         return IoCContainer.get(source);
     }
 


### PR DESCRIPTION
This adds a generic type check to the Container.get function so that the return type is equal to the source parameter type. This way it will not return 'any'. 

There may be breaking changes for code relying on this function. But probably the previous version relied on 'any', thus not working at runtime anyway.