### PR TITLE
Updating the error to include the information about the target type requested.

### DIFF
--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -594,6 +594,6 @@ class InjectorHanlder {
                 return <FunctionConstructor>typeConstructor;
             }
         }
-        throw TypeError('Can not identify the base Type for requested target %s' +  target.toString());
+        throw TypeError('Can not identify the base Type for requested target ' +  target.toString());
     }
 }

--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -594,6 +594,6 @@ class InjectorHanlder {
                 return <FunctionConstructor>typeConstructor;
             }
         }
-        throw TypeError('Can not identify the base Type for requested target');
+        throw TypeError('Can not identify the base Type for requested target %s' +  target.toString());
     }
 }


### PR DESCRIPTION
Allowing to see which injection target was rejected allows us to debug our setup better.