### PR TITLE
Add stronger typing to Container.get() via usage of generics

### DIFF
--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -234,7 +234,7 @@ export class Container {
      * @param source The dependency type to resolve
      * @return an object resolved for the given source type;
      */
-    public static get(source: Function) {
+    public static get<T>(source: Function & {prototype: T}): T {
         return IoCContainer.get(source);
     }
 

--- a/test/unit/test.spec.ts
+++ b/test/unit/test.spec.ts
@@ -278,7 +278,7 @@ describe("Default Implementation class", () => {
 	}
 
 	it("should inform Container that it is the implementation for its base type", () => {
-		const instance: ImplementationClass = Container.get(BaseClass);
+		const instance: ImplementationClass = Container.get(BaseClass) as ImplementationClass;
 		const test = instance['testProp'];
 		expect(test).to.exist;
 	});


### PR DESCRIPTION
First, thanks for your work on this library. I've been using it extensively for over a year now :smile: 

## Motivation

The current `Container.get()` returns `any`, which means you need an explicit type annotation or cast afterward in order to get any type safety.

By using generics, we can make the typescript compiler a little smarter - it can assume that the type you get out of `Container.get()` is the same type you pass to it.

```typescript
// old
const foo = Container.get(Foo); // Inferred type of `foo` is `any`.
const foo: Foo = Container.get(Foo); // Explicit type annotation makes type `foo`.
const foo = Container.get(Foo) as Foo; // Explicit cast make type `foo`.

// new
const foo = Container.get(Foo); // Inferred type of `foo` is `Foo`, no need for type annotations or casting.
```

## The new function signature

I originally tried to use `new(...args: Array<any>): T`, but this doesn't work for abstract classes because abstract constructors don't match that type signature.

So, after seeing https://stackoverflow.com/questions/36886082/abstract-constructor-type-in-typescript#38642922, it looks like the type `Function & {prototype: T}` encompasses both concrete and abstract classes and should cover all use cases