### PR TITLE
allow parametrized resolution of services through getParametrized method

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -215,7 +215,7 @@ function InjectParamDecorator(target: Function, propertyKey: string | symbol, pa
         const config = IoCContainer.bind(target);
         config.paramTypes = config.paramTypes || [];
         const paramTypes: Array<any> = Reflect.getMetadata('design:paramtypes', target);
-        config.paramTypes.unshift(paramTypes[parameterIndex]);
+        config.paramTypes[parameterIndex] = paramTypes[parameterIndex];
     }
 }
 
@@ -233,6 +233,6 @@ function InjectValueParamDecorator(target: Function, propertyKey: string | symbo
     if (!propertyKey) { // only intercept constructor parameters
         const config = IoCContainer.bind(target);
         config.paramTypes = config.paramTypes || [];
-        config.paramTypes.unshift(value);
+        config.paramTypes[_parameterIndex] = value;
     }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -61,6 +61,10 @@ export type ObjectFactory = (context?: BuildContext) => Object;
  * The context of the current Container resolution.
  */
 export abstract class BuildContext {
+    public resetRequestSpecificParameters() { 
+        // do nothing. default implementation does not perform any action
+    }
+    public getRequestSpecificParameters() { return []; }
     public abstract resolve<T>(source: Function & { prototype: T }): T;
     public abstract build<T>(source: Function & { prototype: T }, factory: ObjectFactory): T;
 }

--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -57,6 +57,20 @@ export class Container {
     }
 
     /**
+     * Retrieve an object from the container. It will resolve all dependencies and apply any type replacement
+     * before return the object.
+     * If there is no declared dependency to the given source type, an implicity bind is performed to this type.
+     * if any number of items is provided in the 'params' argument - these items will be used as constructor arguments 
+     * taking over the potential bindings
+     * @param source The dependency type to resolve
+     * @param contextParams list of X parameters, which will be passed as first X constructor arguments
+     * @return an object resolved for the given source type;
+     */
+    public static getParametrized<T>(source: Function & { prototype: T }, ...contextParams: Array<any>): T {
+        return IoCContainer.get(source, new ParametrizedBuildContext(contextParams));
+    }
+
+    /**
      * Retrieve a type associated with the type provided from the container
      * @param source The dependency type to resolve
      * @return an object resolved for the given source type;
@@ -177,5 +191,19 @@ class ContainerBuildContext extends BuildContext {
 
     public resolve<T>(source: Function & { prototype: T }): T {
         return IoCContainer.get(source, this);
+    }
+}
+
+export class ParametrizedBuildContext extends ContainerBuildContext {
+    constructor(private contextParams: Array<any>) {
+        super();
+    }
+
+    public getRequestSpecificParameters() {
+        return this.contextParams;
+    }
+
+    public resetRequestSpecificParameters() {
+        this.contextParams = [];
     }
 }

--- a/test/unit/decorators.spec.ts
+++ b/test/unit/decorators.spec.ts
@@ -54,6 +54,20 @@ describe('@Inject decorator', () => {
 
         expect(testFunction).toThrow(new TypeError('Invalid @Inject Decorator declaration.'));
     });
+
+    it('should inject into proper arguments despite previous arguments are not decorated', () => {
+        const config: any = {};
+        mockBind.mockReturnValue(config);
+
+        class ConstructorInjected {
+            constructor(public anotherDate: Date,
+                @Inject public myProp: String) {
+            }
+        }
+        expect(mockBind).toBeCalledWith(ConstructorInjected);
+        expect(config.paramTypes[0]).toEqual(undefined);
+        expect(config.paramTypes[1]).toEqual(String);
+    });
 });
 
 const mockInjectValueProperty = IoCContainer.injectValueProperty as jest.Mock;
@@ -106,6 +120,20 @@ describe('@InjectValue decorator', () => {
         };
 
         expect(testFunction).toThrow(new TypeError('Invalid @InjectValue Decorator declaration.'));
+    });
+
+    it('should inject into proper arguments despite previous arguments are not decorated', () => {
+        const config: any = {};
+        mockBind.mockReturnValue(config);
+
+        class ConstructorInjected {
+            constructor(public anotherDate: Date,
+                @InjectValue('myString') public myProp: String) {
+            }
+        }
+        expect(mockBind).toBeCalledWith(ConstructorInjected);
+        expect(config.paramTypes[0]).toEqual(undefined);
+        expect(config.paramTypes[1]).toEqual('myString');
     });
 });
 


### PR DESCRIPTION
Hi Thiago,

Thank you for working on typescript-ioc. 
The package is great! To me it looks like the "proper" implementation of IoC container, with regards that information about interfaces is not propagated to runtime.

This PR is a suggestion about supporting the design pattern I am using a lot while working in MVVM approach. It comes from classic WPF's MVVM but the same looks handy while working with typescript UI using MVVM-ish architecture.

The UI is commonly represented with components(controls) tree. In MVVM approach, component is driven by the data, gathered and persisted within the viewmodel, dedicated to this component or to components subtree.

ViewModels essentially have a dependencies on the domain/infrastructural services. This is where IoC container comes to play. 
However, viewmodel might by instantiated within the components subtree so it might rely on the instance-specific parameters.

Consider an example: we have a list of accounts with a complex and comprehensive UI. 
We may want to build a viewmodel-per-account which would have the following dependencies: accountId, accountsDao.
AccountsDao can be injected by IoC container, however accountId is specific to particular viewmodel instance.

Below is an ugly solution I am using at the moment for my actual projects:
```
class AccountVM {
    constructor(accountId: number, accountDao: IAccountsDao = IoC.Container.get(IAccountsDao)) {}
}
````
But this solution prevents from using single resolution context while calling `new AccountVM(accountId)`. Scope.Request is effectively bypassed while working with this approach.


This PR contains the new public function 
`getParametrized<T>(source: Function & { prototype: T }, ...contextParams: Array<any>)`

For the example above, it is supposed to be called this way:

`Container.getParametrized(AccountVM, 1)`

The function replaces first X arguments of constructor with the X values, provided as rest parameters of Container.getParametrized function.



I've added some test coverage to illustrate the usage and the way instance-specific parameters interferes with injected parameters.


Note, that I've also modified the way @Inject decorator for constructor arguments works.
Previously, if developer does this:
```
class Dddd {
        constructor(@Inject a: Aaaa, b: Bbbb, @Inject c: Cccc) {
        }
    }

Container.get(Dddd)
```

instance of type Cccc, would have been injected in the constructor argument having 1st position. So in runtime, one would have variable `b` of type `Cccc`. Even though such usage of decorators is highly questionable, it still doesn't looks as a correct behavior.

Same change is applied to @InjectValue decorator.


Let me know your thoughts about this PR.
I know that adding new methods to the public API should be done with a huge caution so consider this PR as a starting point for conversation, rather than an actual pull request.








