### PR TITLE
fix: Missing NamespaceConfiguration import from module root

### DIFF
--- a/src/typescript-ioc.ts
+++ b/src/typescript-ioc.ts
@@ -16,6 +16,7 @@ export { BuildContext };
 export { Scope };
 export { ContainerConfiguration };
 export { ConstantConfiguration };
+export { NamespaceConfiguration };
 export { Inject, Factory, Singleton, Scoped, OnlyInstantiableByContainer, InRequestScope, InjectValue } from './decorators';
 export { Snapshot };
 


### PR DESCRIPTION
I think it's a safe explanary title but here your can find more informations :
![image](https://github.com/user-attachments/assets/98dd78ab-6cb2-434f-8c1e-089c2289f2f4)
